### PR TITLE
Prevent changing location.hash after clicking Play

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,7 +40,7 @@
       <a
         id="btn"
         style="margin:1rem;text-align:center;"
-        href="#"
+        href="javascript:void(0)"
         onclick="togglePlayback()"
         >Play</a
       >


### PR DESCRIPTION
This bug made it harder for the user to save their work after clicking Play, because the URL was overwritten. Now the URL stays the same.

I don’t see any significant downsides to this solution in the discussion on [Which “href” value should I use for JavaScript links, “#” or “javascript:void(0)”?](https://stackoverflow.com/q/134845/578288)

Other solutions I considered:

- Adding a `onclick` handler to `btn` with JavaScript and calling `e.preventDefault()`
- Writing `onclick="togglePlayback(event)”` in the HTML and calling `e.preventDefault()` inside `togglePlayback`

---

P.S. I made [some compositions](https://lobste.rs/s/gjqa1v/nokia_composer_512_bytes#c_xafcnv) with this tool. Thanks for making it.